### PR TITLE
Avoid RMagick require warning by using lowercase require if possible

### DIFF
--- a/lib/zxing/rmagick/image.rb
+++ b/lib/zxing/rmagick/image.rb
@@ -1,9 +1,14 @@
-require 'RMagick'
+begin
+  # Support both newer 'rmagick' require and deprecated 'RMagick' require:
+  require 'rmagick'
+rescue LoadError => e
+  require 'RMagick'
+end
 
 module ZXing; end
 module ZXing::RMagick; end
 
-class ZXing::RMagick::Image 
+class ZXing::RMagick::Image
   include ZXing::Image
   LuminanceSource = ZXing::FFI::Common::GreyscaleLuminanceSource
 


### PR DESCRIPTION
Using the latest version of RMagick this gem will output the following warning:

```
[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead
```

This PR avoids this by first attempting to require the lowercase 'rmagick' instead.

I can't fully verify the solution as `rake test` exist with an error for me that seems to be unrelated to my changes (I get the same problem on master):

```
LoadError: Could not open library 'lib.so': lib.so: cannot open shared object file: No such file or directory
```

However before those errors are hit the warning is already printed during `rake test` and I can see that the message is gone on this branch.
